### PR TITLE
Correct run command for ArchLinux in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ npm install
 
 ## Run
 
+### Running in ArchLinux
+```bash
+# start ethereum with json-rpc server
+# by default port 8080
+eth -j
+
+# make sure mongodb is running
+sudo systemctl start mongodb.service
+
+# start eth-exchange
+# by default port 2000, configurable in config.js
+npm start
+```
+
+### Running in Debian based distros / Macosx
 ```bash
 # start ethereum with json-rpc server
 # by default port 8080


### PR DESCRIPTION
At least in ArchLinux since you install it from an official package `Mongodb` needs to be ran as a service.

I read around and even in Debian/Ubuntu running it as a service is the recommended way to go. In Debian I think that would be:

``` bash
service mongod start
```
